### PR TITLE
Remove hard dependency on openmicroscopy.docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 install:
-  - pip install 'ome-ansible-molecule-dependencies<0.2'
+  - pip install ome-ansible-molecule-dependencies
 
 script:
   - molecule test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 sudo: required
 language: python
 
@@ -5,7 +6,7 @@ services:
   - docker
 
 install:
-  - pip install ansible docker 'molecule<1.22'
+  - pip install 'ome-ansible-molecule-dependencies<0.2'
 
 script:
   - molecule test

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ All variables are optional:
 - `celery_docker_broker_url`: The URL to the broker, e.g. `redis://HOST:PORT/DB`, default is redis on localhost
 - `celery_docker_log_level`: Celery worker log level, default `DEBUG`
 - `celery_docker_concurrency`: Number of concurrent tasks, default is number of CPUs
-- `celery_docker_max_retries`: Maximum number of times to retry if the `docker` command fails
-- `celery_docker_retry_delay`: Delay (seconds) before retrying a failed task
+- `celery_docker_max_retries`: Maximum number of times to retry if the `docker` command fails, default `3`
+- `celery_docker_retry_delay`: Delay (seconds) before retrying a failed task, default `10`
 - `celery_docker_store_tasks_hours`: Store completed tasks in the broker for this number of hours, default `384` (16 days)
-- `celery_docker_systemd_timeout`: If a Celery worker is stopped (`systemctl stop celery-worker`) wait this number of seconds before killing the worker (this will kill any tasks still in progress), default `7200` (2 hours)
+- `celery_docker_systemd_timeout`: If a Celery worker is stopped with `systemctl stop celery-worker` wait this number of seconds before killing the worker (this will kill any tasks still in progress), default `7200` (2 hours)
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Example playbook
 
     - hosts: localhost
       roles:
+      - role: openmicroscopy.docker
+      - role: openmicroscopy.redis
       - role: celery-docker
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Celery Docker
 =============
 
 Celery distributed processing with Docker.
+This role is considered developmental.
 
 
 Dependencies
@@ -13,6 +14,19 @@ This role requires Docker to be running on the target hosts.
 Celery requires a broker such as Redis, either on the current or a remote server.
 
 For example, you can use the `openmicroscopy.docker` and `openmicroscopy.redis` roles to set them up, see the example playbook.
+
+
+Variables
+---------
+
+All variables are optional:
+- `celery_docker_broker_url`: The URL to the broker, e.g. `redis://HOST:PORT/DB`, default is redis on localhost
+- `celery_docker_log_level`: Celery worker log level, default `DEBUG`
+- `celery_docker_concurrency`: Number of concurrent tasks, default is number of CPUs
+- `celery_docker_max_retries`: Maximum number of times to retry if the `docker` command fails
+- `celery_docker_retry_delay`: Delay (seconds) before retrying a failed task
+- `celery_docker_store_tasks_hours`: Store completed tasks in the broker for this number of hours, default `384` (16 days)
+- `celery_docker_systemd_timeout`: If a Celery worker is stopped (`systemctl stop celery-worker`) wait this number of seconds before killing the worker (this will kill any tasks still in progress), default `7200` (2 hours)
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -9,29 +9,31 @@ Dependencies
 
 See `meta/main.yml`
 
-Note that this uses `openmicroscopy.redis` by default.
-If you have multiple redis users you may want to adjust the database used by each of them.
+This role requires Docker to be running on the target hosts.
+Celery requires a broker such as Redis, either on the current or a remote server.
+
+For example, you can use the `openmicroscopy.docker` and `openmicroscopy.redis` roles to set them up, see the example playbook.
 
 
 Usage
 -----
 
 This role creates a celery worker that launches docker containers.
-For example, the following will submit a task:
+At present a single task is defined, `run_docker`.
+See [celery-worker-tasks.py `run_docker`](files/celery-worker-tasks.py) for a description of the parameters.
 
-    /opt/celery/venv/bin/python /opt/celery/worker/tasks.py
-      --inputpath /celery/in --outputpath /celery/out --out /celery/output.log
-      busybox -- sh -c 'date > /output/date.txt'
+Tasks can be submitted in two ways:
 
-### Parameters
-- `--inputpath /INPUT/PATH`: Input file or directory, mounted inside the Docker container as `/input`
-- `--outputpath /OUTPUT/PATH`: Output file or directory, mounted inside the Docker container as `/output`.
-  The user is responsible for ensuring it is writeable by the Docker container if necessary.
+- Submit a `run_docker` task with arguments passed as a dictionary.
+  For an example of this see [celery-submit-example.py](files/celery-submit-example.py).
 
-For more details run:
+- Run the tasks file directly (a `main` function is included):
 
-    /opt/celery/venv/bin/python /opt/celery/worker/tasks.py --help
+        /opt/celery/venv/bin/python /opt/celery/worker/tasks.py --help
 
+        /opt/celery/venv/bin/python /opt/celery/worker/tasks.py
+          --inputpath /celery/in --outputpath /celery/out --out /celery/output.log
+          busybox -- sh -c 'date > /output/date.txt'
 
 
 Example playbook

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Example playbook
       roles:
       - role: openmicroscopy.docker
       - role: openmicroscopy.redis
-      - role: celery-docker
+      - role: openmicroscopy.celery-docker
 
 
 Advanced setup

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All variables are optional:
 - `celery_docker_broker_url`: The URL to the broker, e.g. `redis://HOST:PORT/DB`, default is redis on localhost
 - `celery_docker_log_level`: Celery worker log level, default `DEBUG`
 - `celery_docker_concurrency`: Number of concurrent tasks, default is number of CPUs
+- `celery_docker_opts`: Additional options for celery worker
 - `celery_docker_max_retries`: Maximum number of times to retry if the `docker` command fails, default `3`
 - `celery_docker_retry_delay`: Delay (seconds) before retrying a failed task, default `10`
 - `celery_docker_store_tasks_hours`: Store completed tasks in the broker for this number of hours, default `384` (16 days)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Tasks can be submitted in two ways:
 - Submit a `run_docker` task with arguments passed as a dictionary.
   For an example of this see [celery-submit-example.py](files/celery-submit-example.py).
 
-- Run the tasks file directly (a `main` function is included):
+- Run the [tasks file](files/celery-worker-tasks.py) directly (a `main` function is included):
 
         /opt/celery/venv/bin/python /opt/celery/worker/tasks.py --help
 
@@ -59,6 +59,30 @@ Example playbook
       - role: openmicroscopy.docker
       - role: openmicroscopy.redis
       - role: celery-docker
+
+
+Advanced setup
+--------------
+
+### Redis security
+
+You can set a [password and other configuration options](http://docs.celeryproject.org/en/latest/getting-started/brokers/redis.html) when starting Redis (`--requirepass`), or in the Redis configuration file.
+All communication is in plain text so this does not guard against network sniffing.
+Redis can [write its data to disk](http://redis.io/topics/persistence) and reload it on startup (`--appendonly yes`) instead of running as an in-memory database.
+For example, if you are running Redis in Docker:
+
+    docker run -d --name redis -p 6379:6379 -v redis-volume:/data redis \
+        --requirepass PASSWORD --appendonly yes
+
+And set `celery_docker_broker_url: redis://:PASSWORD@redis.example.org:6379`
+
+
+### Long-running tasks
+
+The default Celery configuration is designed for handling short tasks.
+There are several changes that can be made to improve the processing of long-running tasks, see the [configuration](http://docs.celeryproject.org/en/latest/configuration.html) and [optimising](http://docs.celeryproject.org/en/latest/userguide/optimizing.html) docs.
+
+For example, use the `-Ofair` option `celery_docker_opts: -Ofair`
 
 
 Author Information

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,10 +2,6 @@
 # defaults file for celery-docker
 
 celery_docker_broker_url: "redis://localhost:6379/0"
-celery_docker_basedir: /opt/celery
-
-celery_docker_var_run: /var/run/celery
-celery_docker_var_log: /var/log/celery
 celery_docker_log_level: DEBUG
 
 # Number of concurrent tasks, 0 = number of CPUs
@@ -16,3 +12,13 @@ celery_docker_retry_delay: 10
 celery_docker_store_tasks_hours: 384
 
 celery_docker_systemd_timeout: 7200
+
+
+######################################################################
+# Expert users only!
+######################################################################
+
+celery_docker_basedir: /opt/celery
+
+celery_docker_var_run: /var/run/celery
+celery_docker_var_log: /var/log/celery

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,6 @@
 celery_docker_broker_url: "redis://localhost:6379/0"
 celery_docker_basedir: /opt/celery
 
-celery_docker_setup_redis: True
 celery_docker_var_run: /var/run/celery
 celery_docker_var_log: /var/log/celery
 celery_docker_log_level: DEBUG

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ celery_docker_log_level: DEBUG
 # Number of concurrent tasks, 0 = number of CPUs
 celery_docker_concurrency: 0
 
+# Additional options for celery worker
+celery_docker_opts: ""
+
 celery_docker_max_retries: 3
 celery_docker_retry_delay: 10
 celery_docker_store_tasks_hours: 384

--- a/files/celery-submit-example.py
+++ b/files/celery-submit-example.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# Example standalone Python script for submitting tasks to celery by passing
+# parameters as keywords only. You do not need access to the original app
+# (tasks.py) file.
+
+from celery import Celery
+
+CELERY_BROKER = 'redis://'
+
+celery = Celery(broker=CELERY_BROKER)
+celery_docker_args = dict(
+    image='manics/pyfeatures:merge',
+    command='calc /input/image1.avro --out-dir /output/image1 ',
+    # Must be writeable by celery:
+    logoutfile='/features/logs/log.txt',
+    # Mounted inside container as /input (read-only):
+    inputpath='/features/input',
+    # Mounted inside container as /output:
+    outputpath='/features/output',
+    user='1000',
+)
+taskid = celery.send_task('tasks.run_docker', kwargs=celery_docker_args)
+print taskid

--- a/files/celery-worker-tasks.py
+++ b/files/celery-worker-tasks.py
@@ -35,6 +35,20 @@ def mkdir_p(path):
 def run_docker(self, image, command, user=None,
                logoutfile=None, logerrfile=None,
                inputpath=None, outputpath=None):
+    """
+    :param image: Docker image, may include a tag
+    :param command: Command line to be passed to image
+    :param user: Run the container as this user
+    :param logoutfile: Absolute host path to an output log file, the parent
+           directory must already exist and must be writeable by the `celery`
+           user
+    :param logerrfile: Not implemented
+    :param inputpath: Absolute host path to the input directory or file,
+           this will be mounted read-only in the container as `/input`
+    :param inputpath: Absolute host path to the output directory or file,
+           this will be mounted in the container as `/output`, must already
+           exist
+    """
 
     client = docker.from_env()
     kwargs = dict(

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,9 +9,3 @@ galaxy_info:
     versions:
     - 7
   galaxy_tags: []
-
-dependencies:
-- role: openmicroscopy.docker
-  docker_use_ipv4_nic_mtu: True
-- role: openmicroscopy.redis
-  when: celery_docker_setup_redis

--- a/molecule.yml
+++ b/molecule.yml
@@ -28,6 +28,14 @@ docker:
     image: openmicroscopy/centos-systemd-ip
     image_version: 0.1.0
     privileged: True
+    ansible_groups:
+    - docker-hosts
+
+ansible:
+  group_vars:
+    docker-hosts:
+      # This should allow docker-in-docker to work
+      docker_storage_driver: vfs
 
 verifier:
   name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,9 @@
 ---
 - hosts: all
   roles:
+    - role: openmicroscopy.docker
+      docker_use_ipv4_nic_mtu: True
+    - role: openmicroscopy.redis
     - role: ansible-role-celery-docker
       celery_docker_max_retries: 1
       celery_docker_retry_delay: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,6 +80,7 @@
   - reload celery-worker
 
 - name: celery docker | system configuration options
+  become: yes
   template:
     dest: /etc/sysconfig/celery-worker
     src: sysconfig-celery-worker.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,12 +79,12 @@
   notify:
   - reload celery-worker
 
-#- name: celery docker | system configuration options
-#  template:
-#    dest: /etc/sysconfig/celery-docker
-#    src: etc-sysconfig-celery-docker.j2
-#  notify:
-#  - reload celery-worker
+- name: celery docker | system configuration options
+  template:
+    dest: /etc/sysconfig/celery-worker
+    src: sysconfig-celery-worker.j2
+  notify:
+  - reload celery-worker
 
 - name: celery docker | worker systemd file
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,7 +91,6 @@
   template:
     dest: "/etc/systemd/system/celery-worker.service"
     src: systemd-system-celery-worker-service.j2
-    mode: 0755
   notify:
   - reload systemd
   - reload celery-worker

--- a/templates/sysconfig-celery-worker.j2
+++ b/templates/sysconfig-celery-worker.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+# Celery systemd environment file
+# http://docs.celeryproject.org/en/latest/userguide/daemonizing.html#generic-systemd-celery-example
+CELERYD_NODES=celery-worker-1
+CELERY_APP=tasks
+CELERYD_LOG_LEVEL={{ celery_docker_log_level }}
+CELERYD_CONCURRENCY={{ celery_docker_concurrency }}
+CELERYD_OPTS={{ celery_docker_opts | quote }}

--- a/templates/systemd-system-celery-worker-service.j2
+++ b/templates/systemd-system-celery-worker-service.j2
@@ -7,18 +7,12 @@ After=network.target
 
 [Service]
 Type=forking
-#PIDFile=/var/run/celery/celery-docker.pid
+#PIDFile=/var/run/celery/celery-worker.pid
 User=celery
 TimeoutStopSec={{ celery_docker_systemd_timeout }}
 WorkingDirectory={{ celery_docker_basedir }}/worker
 
-# http://docs.celeryproject.org/en/latest/userguide/daemonizing.html#generic-systemd-celery-example
-#EnvironmentFile=-/etc/sysconfig/celery
-Environment=CELERYD_NODES=celery-worker-1
-Environment=CELERY_APP=tasks
-Environment=CELERYD_LOG_LEVEL={{ celery_docker_log_level }}
-Environment=CELERYD_CONCURRENCY={{ celery_docker_concurrency }}
-#Environment=CELERYD_OPTS="--time-limit=300"
+EnvironmentFile=-/etc/sysconfig/celery-worker
 
 # The docs suggest "%n%I.log" but this doesn't work
 ExecStart=/bin/sh -c '{{ celery_docker_basedir }}/venv/bin/celery \

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,3 +1,5 @@
 - src: openmicroscopy.basedeps
-- src: openmicroscopy.docker
+- name: openmicroscopy.docker
+  src: https://github.com/manics/ansible-role-docker.git
+  version: docker-refactor
 - src: openmicroscopy.redis

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,5 +1,3 @@
 - src: openmicroscopy.basedeps
-- name: openmicroscopy.docker
-  src: https://github.com/manics/ansible-role-docker.git
-  version: docker-refactor
+- src: openmicroscopy.docker
 - src: openmicroscopy.redis

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -36,10 +36,11 @@ def test_celery_task(Command, File, Sudo):
     # WARNING: If the network is particularly slow the download of busybox
     # may take too long
     for i in xrange(20):
-        f = File('/tmp/celery/output.txt')
+        got_outputs = (File('/tmp/celery/log.out').exists and
+                       File('/tmp/celery/output.txt').exists)
         # Sleep first to allow time for writing
-        sleep(3)
-        if f.exists:
+        sleep(10)
+        if got_outputs:
             break
 
     flog = File('/tmp/celery/log.out')


### PR DESCRIPTION
This role doesn't require any special Docker configuration, so leave it to the user to decide how Docker should be installed. Same goes for Redis.

Todo:
- [x] Revert https://github.com/openmicroscopy/ansible-role-celery-docker/pull/2/commits/14944d9864d3fc59421786bb623c7582d6ce1ea8